### PR TITLE
0.1.45

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'java'
 mainClassName = 'bacnet.Main'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
-version = '0.1.44-SNAPSHOT'
+version = '0.1.45-SNAPSHOT'
 
 repositories {
     mavenCentral()
@@ -18,8 +18,8 @@ repositories {
 }
  
 dependencies {
-    compile 'org.iot-dsa:dslink:0.15.0'
-    compile 'org.iot-dsa:historian:0.15.0'
+    compile 'org.iot-dsa:dslink:0.16.0'
+    compile 'org.iot-dsa:historian:0.16.0'
     compile 'org.apache.commons:commons-lang3:3.0'
     compile 'commons-logging:commons-logging:1.1.1'
     compile 'org.scream3r:jssc:2.8.0'

--- a/dslink.json
+++ b/dslink.json
@@ -1,6 +1,6 @@
 {
   "name": "dslink-java-bacnet",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "A dslink for bacnet",
   "license": "GNU GPL",
   "main": "bin/dslink-java-bacnet",

--- a/src/main/java/bacnet/BacnetIpConnection.java
+++ b/src/main/java/bacnet/BacnetIpConnection.java
@@ -1,12 +1,17 @@
 package bacnet;
 
+import com.serotonin.bacnet4j.exception.BACnetException;
+import com.serotonin.bacnet4j.npdu.Network;
+import com.serotonin.bacnet4j.npdu.ip.IpNetwork;
+import com.serotonin.bacnet4j.npdu.ip.IpNetworkBuilder;
+import com.serotonin.bacnet4j.npdu.ip.IpNetworkUtils;
+import com.serotonin.bacnet4j.type.primitive.OctetString;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.dsa.iot.dslink.node.Node;
 import org.dsa.iot.dslink.node.actions.Action;
 import org.dsa.iot.dslink.node.actions.ActionResult;
@@ -15,13 +20,6 @@ import org.dsa.iot.dslink.node.value.Value;
 import org.dsa.iot.dslink.node.value.ValueType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.serotonin.bacnet4j.exception.BACnetException;
-import com.serotonin.bacnet4j.npdu.Network;
-import com.serotonin.bacnet4j.npdu.ip.IpNetwork;
-import com.serotonin.bacnet4j.npdu.ip.IpNetworkBuilder;
-import com.serotonin.bacnet4j.npdu.ip.IpNetworkUtils;
-import com.serotonin.bacnet4j.type.primitive.OctetString;
 
 public class BacnetIpConnection extends BacnetConn {
 	private static final Logger LOGGER;
@@ -71,21 +69,19 @@ public class BacnetIpConnection extends BacnetConn {
 			entry = entry.trim();
 			if (!entry.isEmpty()) {
 				Pattern p = Pattern.compile("^\\s*(.*?):(\\d+):(\\d+)$");
-				Matcher m = p.matcher(entry);
-				if (m.matches()) {
-					bbmdIp = m.group(1);
-					bbmdPort = Integer.parseInt(m.group(2));
-					networkNumber = Integer.parseInt(m.group(3));
-				}
-				bbmdIpToPort.put(bbmdIp, bbmdPort);
-
-				if (!bbmdIp.isEmpty()) {
-					OctetString os = IpNetworkUtils.toOctetString(bbmdIp, bbmdPort);
-					networkRouters.put(networkNumber, os);
-				}
-
-			}
-		}
+                Matcher m = p.matcher(entry);
+                if (m.matches()) {
+                    bbmdIp = m.group(1);
+                    bbmdPort = Integer.parseInt(m.group(2));
+                    networkNumber = Integer.parseInt(m.group(3));
+                    if (!bbmdIp.isEmpty()) {
+                        bbmdIpToPort.put(bbmdIp, bbmdPort);
+                        OctetString os = IpNetworkUtils.toOctetString(bbmdIp, bbmdPort);
+                        networkRouters.put(networkNumber, os);
+                    }
+                }
+            }
+        }
 	}
 
 	@Override


### PR DESCRIPTION
- Update SDK dependency.
- Fix NPE emanating from BacnetIpConnection

@hhou2011 - Please review.  The following was the exception being fixed:

[2016-11-23 23:51:39.021196] == Executing c:\DSA\dglux-server\dslinks\dslink-java-bacnet\bin\dslink-java-bacnet.bat with arguments [--name, BACnet, --nodes, nodes.json, --key, .key, --log, info, --broker, http://127.0.0.1:62633/conn, --token, IdIdbC5Wn8MxBaIspZVI1xrz8IRoXIPDcJC4n4HtjDmPrkW8] (pid: 3044) ==
[2016-11-23 23:51:40.062266] 2016-11-23 23:51:40.062 [Thread-2] INFO bacnet.Main - Initialized
[2016-11-23 23:51:40.077896] Exception in thread "Thread-2" java.lang.NullPointerException
[2016-11-23 23:51:40.077896]     at bacnet.BacnetIpConnection.parseBroadcastManagementDevice(BacnetIpConnection.java:82)
[2016-11-23 23:51:40.077896]     at bacnet.BacnetIpConnection.<init>(BacnetIpConnection.java:55)
[2016-11-23 23:51:40.077896]     at bacnet.BacnetLink.restoreLastSession(BacnetLink.java:247)
[2016-11-23 23:51:40.077896]     at bacnet.BacnetLink.init(BacnetLink.java:67)
[2016-11-23 23:51:40.077896]     at bacnet.BacnetLink.start(BacnetLink.java:62)
[2016-11-23 23:51:40.077896]     at bacnet.Main.onResponderInitialized(Main.java:53)
[2016-11-23 23:51:40.093507]     at org.dsa.iot.dslink.DSLinkProvider$1$2.run(DSLinkProvider.java:123)
[2016-11-23 23:51:40.093507]     at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
[2016-11-23 23:51:40.093507]     at java.util.concurrent.FutureTask.run(Unknown Source)
[2016-11-23 23:51:40.093507]     at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(Unknown Source)
[2016-11-23 23:51:40.093507]     at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
[2016-11-23 23:51:40.093507]     at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
[2016-11-23 23:51:40.093507]     at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
[2016-11-23 23:51:40.093507]     at java.lang.Thread.run(Unknown Source)